### PR TITLE
Empty state for jobs search

### DIFF
--- a/app/views/jobs/index.html.haml
+++ b/app/views/jobs/index.html.haml
@@ -35,8 +35,10 @@
       .col.sm-col-8
         .mb2.purple{style: "border-bottom:solid 5px;"}
         - if @featured
-          =render @featured, feature: true
-        =render @jobs, feature: false
+          = render @featured, feature: true
+        = render @jobs, feature: false
+        - if @jobs.empty? && !@featured
+          Sorry, no jobs matched your search parameters
 
       .col.sm-col-4.px3
         .clearfix


### PR DESCRIPTION
- Made sure not to show the empty state if a featured job is being shown
- Want it to say something different? 

**After:**
![image](https://cloud.githubusercontent.com/assets/987305/15987012/f464f5c2-2fd6-11e6-8c29-0fba498e4f99.png)

**Before:**
![image](https://cloud.githubusercontent.com/assets/987305/15987015/0cba70a2-2fd7-11e6-8459-5e4b9289a014.png)


