### PR TITLE
fixed the spelling error in article.rb

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,7 +10,7 @@ class Article < ActiveRecord::Base
   html_schema_type :TechArticle
 
   BIG_BANG = Time.parse("05/07/2012").to_i #date protips were launched
-  before_update :cache_cacluated_score!
+  before_update :cache_calculated_score!
   before_create :generate_public_id, if: :public_id_blank?
   after_create  :auto_like_by_author
 
@@ -109,7 +109,7 @@ class Article < ActiveRecord::Base
     public_id.blank?
   end
 
-  def cache_cacluated_score!
+  def cache_calculated_score!
     self.score = cacluate_score
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 20160608034824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "citext"
-  enable_extension "pg_stat_statements"
   enable_extension "uuid-ossp"
 
   create_table "badges", force: :cascade do |t|


### PR DESCRIPTION
Previously, in the `article.rb/protip.rb`, the spelling of `cache_calculated_score` was taken for `cache_cacluated_score`. This PR resolves issue #39 